### PR TITLE
Allows image list to be built without an 'imageinfo' key.

### DIFF
--- a/dumpgenerator.py
+++ b/dumpgenerator.py
@@ -1038,7 +1038,12 @@ def getImageNamesAPI(config={}, session=None):
                 # print jsonimages['query']
 
                 for image, props in jsonimages['query']['pages'].items():
-                    url = props['imageinfo'][0]['url']
+                    try:
+                        url = props['imageinfo'][0]['url']
+                    except KeyError, e:
+                        print 'Warning: no key "imageinfo" for %s, skipping.' % props
+                        continue
+                    
                     url = curateImageURL(config=config, url=url)
 
                     tmp_filename = ':'.join(props['title'].split(':')[1:])


### PR DESCRIPTION
This change allows a potentially partial image list to be constructed and downloaded when some items do not have an 'imageinfo' key.  The behavior was observed when dumping sites running older versions of MediaWiki (<=1.10).
